### PR TITLE
Mapusing matchoutcome

### DIFF
--- a/FluentFunctionalCoding/FluentFunctionalCoding/FluentExtensions/Map/Map.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCoding/FluentExtensions/Map/Map.cs
@@ -11,5 +11,20 @@
         /// <param name="mapFunc">The mapping function to apply.</param>
         /// <returns>The result of applying <paramref name="mapFunc"/> to <paramref name="subjectToMap"/>, or default if <paramref name="subjectToMap"/> is null.</returns>
         public static K Map<T, K>(this T subjectToMap, Func<T, K> mapFunc) => subjectToMap == null ? default : mapFunc(subjectToMap);
+
+        /// <summary>
+        /// Applies the specified mapping function to the subject inside a using statement and returns the result.
+        /// </summary>
+        /// <typeparam name="T">The type of the input subject, must implement IDisposable.</typeparam>
+        /// <typeparam name="K">The type of the result after mapping.</typeparam>
+        /// <param name="subjectToMap">The object to map from.</param>
+        /// <param name="mapFunc">The mapping function to apply.</param>
+        /// <returns>The result of applying <paramref name="mapFunc"/> to <paramref name="subjectToMap"/>, or default if <paramref name="subjectToMap"/> is null.</returns>
+        public static K MapUsing<T, K>(this T subjectToMap, Func<T, K> mapFunc) where T : IDisposable
+        {
+            if (subjectToMap == null) return default!;
+            using (subjectToMap)
+                return mapFunc(subjectToMap);
+        }
     }
 }

--- a/FluentFunctionalCoding/FluentFunctionalCoding/FluentFunctionalCoding.csproj
+++ b/FluentFunctionalCoding/FluentFunctionalCoding/FluentFunctionalCoding.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<Title>Expand linq fluent methods with some useful constructs for developing code</Title>
 		<Authors>Samuele Bartolucci</Authors>
 		<Description>
@@ -17,19 +17,20 @@ The library aims to enable expressive, safe, and concise code by leveraging func
 		<PackageProjectUrl>https://github.com/SamueleBartolucci/FluentFunctionalCoding</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/SamueleBartolucci/FluentFunctionalCoding</RepositoryUrl>
 		<PackageReleaseNotes>
-			=> 1.1.0: Introduced retry functionality for the Try fluent type: all Try preludes now include a new parameter, numRetry, with a default value of 1.
+=&gt; 1.1.1: Introduced MapUsing to apply a Map inside a using statement, for types, T, Outcome and Optional
+ 			 Introduced MatchToOutcome to directly convert a Match result into an Outcome.
+			
+FluentCoding Rewrite that includes:
+Fluent Extensions: Do, Map, Or, and more for collections, tasks, and primitives.
+Fluent Types:
+- Try: Functional try/catch with fluent error handling.
+- SwitchMap: Fluent pattern matching for values and collections.
+- When: Fluent conditional logic for values and collections.
+Functional Types
+- Outcome: Functional Either type for success/failure flows.
+- Optional: Safe handling of values that may or may not exist.
 
-			FluentCoding Rewrite that includes:
-			Fluent Extensions: Do, Map, Or, and more for collections, tasks, and primitives.
-			Fluent Types:
-			- Try: Functional try/catch with fluent error handling.
-			- SwitchMap: Fluent pattern matching for values and collections.
-			- When: Fluent conditional logic for values and collections.
-			Functional Types
-			- Outcome: Functional Either type for success/failure flows.
-			- Optional: Safe handling of values that may or may not exist.
-
-			Consilidated naming and functionalities across types and extensions, hidden lots extension into intenal classes, replaced some lambda delegate with a more structured fluent notation.
+Consolidated naming and functionalities across types and extensions, hidden lots of extension into internal classes, replaced some lambda delegate with a more structured fluent notation.
 		</PackageReleaseNotes>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/FluentFunctionalCoding/FluentFunctionalCoding/FluentTypes/When/WhenMatch/When.Match.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCoding/FluentTypes/When/WhenMatch/When.Match.cs
@@ -34,5 +34,18 @@
         /// </summary>        
         /// <returns>The mapped or original subject.</returns>
         public T Match() => _subject;
+
+        /// <summary>
+        /// Applies the specified mapping functions depending on whether the condition is true or false, and converts the result to an Outcome.
+        /// </summary>
+        /// <typeparam name="F">The failure type of the Outcome.</typeparam>
+        /// <typeparam name="S">The success type of the Outcome.</typeparam>
+        /// <param name="mapOnTrue">The function to apply if the condition is true, returning a success value.</param>
+        /// <param name="mapOnFalse">The function to apply if the condition is false, returning a failure value.</param>
+        /// <returns>An Outcome representing the result of the selected mapping function.</returns>
+        public Outcome<F, S> MatchToOutcome<F, S>(Func<T, S> mapOnTrue, Func<T, F> mapOnFalse)
+            => IsTrue
+                ? Outcome<F, S>.Right(mapOnTrue(_subject))
+                : Outcome<F, S>.Left(mapOnFalse(_subject));
     }
 }

--- a/FluentFunctionalCoding/FluentFunctionalCoding/FunctionalTypes/Optional/Optional.IDisposable.Map.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCoding/FunctionalTypes/Optional/Optional.IDisposable.Map.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics.Contracts;
+using static FluentFunctionalCoding.FluentExtension;
+
+
+namespace FluentFunctionalCoding
+{
+    /// <summary>
+    /// Provides methods for mapping (transforming) Optional values.
+    /// </summary>
+    public static partial class WhenForTasks
+    {
+        /// <summary>
+        /// Transforms the contained value if present (Some) using the provided function, disposing the value after mapping. Only available for IDisposable types.
+        /// </summary>
+        /// <typeparam name="O">The inner value when Some</typeparam>
+        /// <typeparam name="B">The result type of the map function</typeparam>
+        /// <param name="optional"></param>
+        /// <param name="mapOnSome">>Function to apply if value is present.</param>
+        /// <returns>An Optional of type B.</returns>
+        [Pure]
+        public static Optional<B> MapUsing<O, B>(this Optional<O> optional, Func<O, B> mapOnSome) where O :IDisposable =>
+            optional switch
+            {
+                None<O> => Optional<B>.None(),
+                Some<O>(var v) => Optional<B>.Some(v.MapUsing(mapOnSome)),
+                _ => throw Optional<O>.UnknowOptionalType()
+            };
+    }
+}

--- a/FluentFunctionalCoding/FluentFunctionalCoding/FunctionalTypes/Outcome/Outcome.IDisposable.Map.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCoding/FunctionalTypes/Outcome/Outcome.IDisposable.Map.cs
@@ -1,0 +1,23 @@
+﻿namespace FluentFunctionalCoding
+{
+
+    public static partial class OutcomeExtensions
+    {
+        /// <summary>
+        /// Maps the success value using the provided function, disposing the value after mapping if it implements IDisposable.
+        /// </summary>
+        /// <typeparam name="L">The value when outcome is Left</typeparam>
+        /// <typeparam name="R">The value when outcome is Right </typeparam>
+        /// <typeparam name="TResult">The result type</typeparam>
+        /// <param name="outcome"></param>
+        /// <param name="mapSuccess">The mapping function to apply to the success value</param>
+        /// <returns>An Outcome with the mapped success value, or the original failure.</returns>
+        public static Outcome<L, TResult> MapUsing<L, R,TResult>(this Outcome<L,R> outcome, Func<R, TResult> mapSuccess) where R:IDisposable =>        
+            outcome switch
+            {
+                Right<L, R> (var rightValue)=> new Right<L, TResult>(rightValue.MapUsing(mapSuccess)),
+                Left<L, R>(var leftValue) => new Left<L, TResult>(leftValue),
+                _ => throw Outcome<L, TResult>.UnknownOutcomeType()
+            };      
+    }
+}

--- a/FluentFunctionalCoding/FluentFunctionalCoding/FunctionalTypes/Outcome/Type.Outcome.Left.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCoding/FunctionalTypes/Outcome/Type.Outcome.Left.cs
@@ -9,8 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Left{F, S}"/> record with the specified failure value.
         /// </summary>
-        /// <param name="SuccessValue">The failure value to store.</param>
-        internal Left(F SuccessValue) => (_failureValue) = (SuccessValue);
+        /// <param name="failureValue">The failure value to store.</param>
+        internal Left(F failureValue) => (_failureValue) = (failureValue);
 
         /// <inheritdoc/>
         public override bool IsSuccess => false;

--- a/FluentFunctionalCoding/FluentFunctionalCodingTest/FluentTypes/When/WhenMatch/When.Tests.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCodingTest/FluentTypes/When/WhenMatch/When.Tests.cs
@@ -49,5 +49,30 @@ namespace FluentFunctionalCodingTest.FluentTypes.When.WhenMatch
             var result2 = whenTrue.MatchFalse(x => x + 2);
             result2.Should().Be(10);
         }
+
+        [Test]
+        public void MatchToOutcome_ShouldReturnRightOrLeft_BasedOnCondition()
+        {
+            var whenTrue = new When<int>(5, true);
+            var outcomeTrue = whenTrue.MatchToOutcome(
+                mapOnTrue: v => v * 2,
+                mapOnFalse: v => $"fail-{v}"
+            );
+            if (outcomeTrue is Right<string, int> right)
+                right._successValue.Should().Be(10);
+            else
+                Assert.Fail("Expected Right outcome");
+
+            var whenFalse = new When<int>(7, false);
+            var outcomeFalse = whenFalse.MatchToOutcome(
+                mapOnTrue: v => v * 2,
+                mapOnFalse: v => $"fail-{v}"
+            );
+            if (outcomeFalse is Left<string, int> left)
+                left._failureValue.Should().Be("fail-7");
+            else
+                Assert.Fail("Expected Left outcome");
+        }
+
     }
 }

--- a/FluentFunctionalCoding/FluentFunctionalCodingTest/FunctionalTypes/Optional/Optional.IDisposable.Map.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCodingTest/FunctionalTypes/Optional/Optional.IDisposable.Map.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using FluentFunctionalCoding;
+using FluentFunctionalCoding.FluentPreludes;
+using NUnit.Framework;
+
+namespace FluentCodingTest.Optional.Map
+{
+    internal class OptionalIDisposableMap
+    {
+        private class DisposableTest : System.IDisposable
+        {
+            public bool Disposed { get; private set; }
+            public int Value { get; }
+            public DisposableTest(int value) { Value = value; }
+            public void Dispose() { Disposed = true; }
+        }
+        
+        [Test]
+        public void Some_MapUsing_DisposesAndMaps()
+        {
+            var disposable = new DisposableTest(42);
+            var opt = disposable.ToOptional();
+            var mapped = opt.MapUsing(d => d.Value + 1);
+            mapped.Should().BeOfType<Some<int>>();
+            ((Some<int>?)mapped)?._value.Should().Be(43);
+            disposable.Disposed.Should().BeTrue();
+        }
+
+        [Test]
+        public void None_MapUsing_DoesNotCallMapOrDispose()
+        {
+            var opt = Optional<DisposableTest>.None();
+            var mapped = opt.MapUsing(d => d.Value + 1);
+            mapped.Should().BeOfType<None<int>>();
+        }
+    }
+}

--- a/FluentFunctionalCoding/FluentFunctionalCodingTest/FunctionalTypes/Outcome/Outcome.IDisposable.Map.cs
+++ b/FluentFunctionalCoding/FluentFunctionalCodingTest/FunctionalTypes/Outcome/Outcome.IDisposable.Map.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using FluentFunctionalCoding;
+using FluentFunctionalCoding.FluentPreludes;
+using NUnit.Framework;
+
+namespace FluentCodingTest.Outcome.Map
+{
+    internal class OutcomeIDisposableMap
+    {
+        private class DisposableTest : System.IDisposable
+        {
+            public bool Disposed { get; private set; }
+            public string Value { get; }
+            public DisposableTest(string value) { Value = value; }
+            public void Dispose() { Disposed = true; }
+        }
+
+        [Test]
+        public void Success_MapUsing_DisposesAndMaps()
+        {
+            var disposable = new DisposableTest("abc");
+            var outcome = new Right<Exception, DisposableTest>(disposable);
+            var mapped = outcome.MapUsing(d => d.Value.Length);
+            mapped.Should().BeOfType<Right<Exception, int>>();
+            ((Right<Exception, int>?)mapped)?._successValue.Should().Be(3);
+            disposable.Disposed.Should().BeTrue();
+        }
+
+        [Test]
+        public void Failure_MapUsing_DoesNotCallMapOrDispose()
+        {
+            var outcome = new Left<Exception, DisposableTest>(new Exception("fail"));
+            var mapped = outcome.MapUsing(d => d.Value.Length);
+            mapped.Should().BeOfType<Left<Exception, int>>();
+        }
+    }
+}


### PR DESCRIPTION
Introduced MapUsing to apply a Map inside a using statement, for types, T, Outcome and Optional
Introduced MatchToOutcome to directly convert a Match result into an Outcome.
			